### PR TITLE
bug fix with wrong dns port number

### DIFF
--- a/fancyss/ss/ssconfig.sh
+++ b/fancyss/ss/ssconfig.sh
@@ -5676,7 +5676,7 @@ finish_start(){
 
 		local FDNS_OK_FLAG_2=0
 		if [ "${ss_basic_chng_trust_2_enable}" == "1" ];then
-			if [ "${ss_basic_chng_trust_2_ecs}" == "1" ];then
+			if [ "${ss_basic_chng_trust_2_ecs}" == "1" -a "${ss_basic_chng_trust_2_opt_doh}" != "97" ];then
 				local TPORT=2056
 			else
 				local TPORT=1056


### PR DESCRIPTION
**1. 启动脚本通过是否勾选ecs来判断采用1056还是2056端口：**

```
		if [ "${ss_basic_chng_trust_2_enable}" == "1" ];then
			if [ "${ss_basic_chng_trust_2_ecs}" == "1" ];then
				local TPORT=2056
			else
				local TPORT=1056
			fi
```

但是如果DNS-2选择的是SmartDNS，则此时ECS的选框是不显示的，但是默认是勾选的（值默认为1），此时就会导致上述启动脚本错误的进行到2056端口的分支（ss_basic_chng_trust_2_ecs=1）。从而导致启动失败： <img width="362" alt="image" src="https://user-images.githubusercontent.com/9136591/207930232-1861a86e-eefe-4ec4-a3df-93649a60a0d2.png">

**2. 临时解决方法**：

先将smartdns改成其他，让ECS的选框出来，并取消勾选
<img width="458" alt="image" src="https://user-images.githubusercontent.com/9136591/207930388-b0f5ff78-9795-4eed-bb3b-a69872bb0158.png"> 然后再切回smartdns，保存是正常1056端口：
<img width="422" alt="image" src="https://user-images.githubusercontent.com/9136591/207930670-9a6c2bc0-860c-4ad7-a8a9-e222dcb060a8.png">

**3. 永久解决办法：**

启动脚本增加判断条件，判断为smartdns时使用1056端口，fixed